### PR TITLE
Добавлена версия V1 счетчиков HTTP сервера

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,12 +16,14 @@ func httpServerExample() {
 	// Метрики конкретного запроса
 	httpServerRequestMetricsBar := metrics.NewHttpServerRequestMetrics("/bar")
 
+	supplierOldId := 999
+
 	// Обработчик для 404
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		httpServerMetrics.IncNbConnections()
 		defer httpServerMetrics.DecNbConnections()
 
-		httpServerMetrics.IncNotFound(r.URL.Path)
+		httpServerMetrics.IncNotFound(r.URL.Path, supplierOldId)
 	})
 
 	// Обработчик /bar
@@ -32,8 +34,8 @@ func httpServerExample() {
 		since := time.Now()
 		status := http.StatusOK
 		defer func() {
-			httpServerRequestMetricsBar.RequestDuration(time.Since(since))
-			httpServerRequestMetricsBar.IncNbRequest(status)
+			httpServerRequestMetricsBar.RequestDuration(time.Since(since), supplierOldId)
+			httpServerRequestMetricsBar.IncNbRequest(status, supplierOldId)
 		}()
 
 		w.WriteHeader(status)

--- a/metrics/db_metrics.go
+++ b/metrics/db_metrics.go
@@ -16,18 +16,18 @@ type IDbMetrics interface {
 
 func NewDbMetrics(dbName string) IDbMetrics {
 	labels := map[string]string{
-		metricsLabelDatabase: dbName,
+		MetricsLabelDatabase: dbName,
 	}
 
 	return &dbMetrics{
-		nbMaxConns:        newGauge(metricsNamespace, metricsSubsystemDb, "max_conns", labels),
-		nbOpenConns:       newGauge(metricsNamespace, metricsSubsystemDb, "open_conns", labels),
-		nbUsedConns:       newGauge(metricsNamespace, metricsSubsystemDb, "used_conns", labels),
-		waitCount:         newGauge(metricsNamespace, metricsSubsystemDb, "wait_count", labels),
-		waitDurationMs:    newSummary(metricsNamespace, metricsSubsystemDb, "wait_duration_count", labels),
-		maxIdleClosed:     newCounter(metricsNamespace, metricsSubsystemDb, "max_idle_closed", labels),
-		maxIdleTimeClosed: newCounter(metricsNamespace, metricsSubsystemDb, "max_idle_time_closed", labels),
-		maxLifetimeClosed: newCounter(metricsNamespace, metricsSubsystemDb, "max_lifetime_closed", labels),
+		nbMaxConns:        NewGauge(MetricsNamespace, metricsSubsystemDb, "max_conns", labels),
+		nbOpenConns:       NewGauge(MetricsNamespace, metricsSubsystemDb, "open_conns", labels),
+		nbUsedConns:       NewGauge(MetricsNamespace, metricsSubsystemDb, "used_conns", labels),
+		waitCount:         NewGauge(MetricsNamespace, metricsSubsystemDb, "wait_count", labels),
+		waitDurationMs:    NewSummary(MetricsNamespace, metricsSubsystemDb, "wait_duration_count", labels),
+		maxIdleClosed:     NewCounter(MetricsNamespace, metricsSubsystemDb, "max_idle_closed", labels),
+		maxIdleTimeClosed: NewCounter(MetricsNamespace, metricsSubsystemDb, "max_idle_time_closed", labels),
+		maxLifetimeClosed: NewCounter(MetricsNamespace, metricsSubsystemDb, "max_lifetime_closed", labels),
 	}
 }
 

--- a/metrics/db_query_metrics.go
+++ b/metrics/db_query_metrics.go
@@ -20,7 +20,7 @@ func NewDbQueryMetrics(dbName, queryName string) IDbQueryMetrics {
 	}
 
 	return &dbRequestMetrics{
-		durationMs: newHistogram(MetricsNamespace, metricsSubsystemDbQuery, "duration_ms", labels, DefaultDurationMsBuckets),
+		durationMs: NewHistogram(MetricsNamespace, metricsSubsystemDbQuery, "duration_ms", labels, DefaultDurationMsBuckets),
 		nbDone:     NewCounter(MetricsNamespace, metricsSubsystemDbQuery, "nb_done", labels),
 		nbError:    NewCounter(MetricsNamespace, metricsSubsystemDbQuery, "nb_error", labels),
 	}

--- a/metrics/db_query_metrics.go
+++ b/metrics/db_query_metrics.go
@@ -15,14 +15,14 @@ type IDbQueryMetrics interface {
 
 func NewDbQueryMetrics(dbName, queryName string) IDbQueryMetrics {
 	labels := map[string]string{
-		metricsLabelDatabase:      dbName,
-		metricsLabelDatabaseQuery: queryName,
+		MetricsLabelDatabase:      dbName,
+		MetricsLabelDatabaseQuery: queryName,
 	}
 
 	return &dbRequestMetrics{
-		durationMs: newHistogram(metricsNamespace, metricsSubsystemDbQuery, "duration_ms", labels, DefaultDurationMsBuckets),
-		nbDone:     newCounter(metricsNamespace, metricsSubsystemDbQuery, "nb_done", labels),
-		nbError:    newCounter(metricsNamespace, metricsSubsystemDbQuery, "nb_error", labels),
+		durationMs: newHistogram(MetricsNamespace, metricsSubsystemDbQuery, "duration_ms", labels, DefaultDurationMsBuckets),
+		nbDone:     NewCounter(MetricsNamespace, metricsSubsystemDbQuery, "nb_done", labels),
+		nbError:    NewCounter(MetricsNamespace, metricsSubsystemDbQuery, "nb_error", labels),
 	}
 }
 
@@ -43,12 +43,13 @@ func (m *dbRequestMetrics) IncError(error) {
 }
 
 /*
-	Helper для быстрого расчета метрик запроса. Плюсом идет то, что метод сам анализирует ошибку и может инкрементить
-	нужные вспомогательные метрики.
+Helper для быстрого расчета метрик запроса. Плюсом идет то, что метод сам анализирует ошибку и может инкрементить
+нужные вспомогательные метрики.
 
-	Пример:
+Пример:
 
-	```
+```
+
 	func SomeDatabaseMethod() (e error){
 		defer func(from time.Time) {
 			metrics.DbQueryMetricsHelper(metrics, from, e)
@@ -56,7 +57,8 @@ func (m *dbRequestMetrics) IncError(error) {
 
 		// Your code goes here
 	}
-	```
+
+```
 */
 func DbQueryMetricsHelper(m IDbQueryMetrics, startTm time.Time, err error) {
 	m.QueryDuration(time.Since(startTm))

--- a/metrics/http_clt_req.go
+++ b/metrics/http_clt_req.go
@@ -28,14 +28,14 @@ func NewHttpClientRequestMetrics(clientName, methodName string) IHttpClientReque
 
 func NewHttpClientRequestMetricsWithBuckets(clientName, methodName string, requestTimeMsBuckets []float64) IHttpClientRequestMetrics {
 	labels := map[string]string{
-		metricsLabelClient: clientName,
-		metricsLabelMethod: methodName,
+		MetricsLabelClient: clientName,
+		MetricsLabelMethod: methodName,
 	}
 
 	m := &httpClientMetrics{
-		nbDone:        newCounterVec(metricsNamespace, metricsSubsystemHttpClt, "nb_req_done", labels, []string{metricsLabelStatusCode}),
-		nbError:       newCounter(metricsNamespace, metricsSubsystemHttpClt, "nb_req_error", labels),
-		requestTimeMs: newHistogram(metricsNamespace, metricsSubsystemHttpClt, "req_duration_ms", labels, requestTimeMsBuckets),
+		nbDone:        NewCounterVec(MetricsNamespace, metricsSubsystemHttpClt, "nb_req_done", labels, []string{MetricsLabelStatusCode}),
+		nbError:       NewCounter(MetricsNamespace, metricsSubsystemHttpClt, "nb_req_error", labels),
+		requestTimeMs: newHistogram(MetricsNamespace, metricsSubsystemHttpClt, "req_duration_ms", labels, requestTimeMsBuckets),
 	}
 
 	m.nbDone200 = m.nbDone.WithLabelValues("200") // recommended optimization

--- a/metrics/http_clt_req.go
+++ b/metrics/http_clt_req.go
@@ -35,7 +35,7 @@ func NewHttpClientRequestMetricsWithBuckets(clientName, methodName string, reque
 	m := &httpClientMetrics{
 		nbDone:        NewCounterVec(MetricsNamespace, metricsSubsystemHttpClt, "nb_req_done", labels, []string{MetricsLabelStatusCode}),
 		nbError:       NewCounter(MetricsNamespace, metricsSubsystemHttpClt, "nb_req_error", labels),
-		requestTimeMs: newHistogram(MetricsNamespace, metricsSubsystemHttpClt, "req_duration_ms", labels, requestTimeMsBuckets),
+		requestTimeMs: NewHistogram(MetricsNamespace, metricsSubsystemHttpClt, "req_duration_ms", labels, requestTimeMsBuckets),
 	}
 
 	m.nbDone200 = m.nbDone.WithLabelValues("200") // recommended optimization

--- a/metrics/http_srv.go
+++ b/metrics/http_srv.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	metricsSubsystemHttpServer = "http_srv"
+	MetricsSubsystemHttpServer = "http_srv"
 )
 
 type IHttpServerMetrics interface {
@@ -25,12 +25,12 @@ func (m *NoHttpServerMetrics) IncMethodNotAllowed(string, string, int) {}
 
 func NewHttpServerMetrics() IHttpServerMetrics {
 	labels := map[string]string{
-		metricsLabelMethod: "",
+		MetricsLabelMethod: "",
 	}
 
 	m := &httpServerMetrics{
-		nbConnections: newGauge(metricsNamespace, metricsSubsystemHttpServer, "current_conns", nil),
-		nbRequests:    newCounterVec(metricsNamespace, metricsSubsystemHttpServer, "nb_req", labels, []string{metricsLabelStatusCode, metricsLabelSupplierOldId}),
+		nbConnections: NewGauge(MetricsNamespace, MetricsSubsystemHttpServer, "current_conns", nil),
+		nbRequests:    NewCounterVec(MetricsNamespace, MetricsSubsystemHttpServer, "nb_req", labels, []string{MetricsLabelStatusCode, MetricsLabelSupplierOldId}),
 	}
 	return m
 }

--- a/metrics/http_srv_req.go
+++ b/metrics/http_srv_req.go
@@ -28,7 +28,7 @@ func NewHttpServerRequestMetricsWithBuckets(methodName string, requestTimeMsBuck
 	}
 	m := &httpServerRequestMetrics{
 		nbRequests:    NewCounterVec(MetricsNamespace, MetricsSubsystemHttpServer, "nb_req", labels, []string{MetricsLabelStatusCode, MetricsLabelSupplierOldId}),
-		requestTimeMs: newHistogram(MetricsNamespace, MetricsSubsystemHttpServer, "req_duration_ms", labels, requestTimeMsBuckets),
+		requestTimeMs: NewHistogram(MetricsNamespace, MetricsSubsystemHttpServer, "req_duration_ms", labels, requestTimeMsBuckets),
 	}
 	return m
 }

--- a/metrics/http_srv_req.go
+++ b/metrics/http_srv_req.go
@@ -24,11 +24,11 @@ func NewHttpServerRequestMetrics(methodName string) IHttpServerRequestMetrics {
 
 func NewHttpServerRequestMetricsWithBuckets(methodName string, requestTimeMsBuckets []float64) IHttpServerRequestMetrics {
 	labels := map[string]string{
-		metricsLabelMethod: methodName,
+		MetricsLabelMethod: methodName,
 	}
 	m := &httpServerRequestMetrics{
-		nbRequests:    newCounterVec(metricsNamespace, metricsSubsystemHttpServer, "nb_req", labels, []string{metricsLabelStatusCode, metricsLabelSupplierOldId}),
-		requestTimeMs: newHistogram(metricsNamespace, metricsSubsystemHttpServer, "req_duration_ms", labels, requestTimeMsBuckets),
+		nbRequests:    NewCounterVec(MetricsNamespace, MetricsSubsystemHttpServer, "nb_req", labels, []string{MetricsLabelStatusCode, MetricsLabelSupplierOldId}),
+		requestTimeMs: newHistogram(MetricsNamespace, MetricsSubsystemHttpServer, "req_duration_ms", labels, requestTimeMsBuckets),
 	}
 	return m
 }

--- a/metrics/http_srv_rq_v1.go
+++ b/metrics/http_srv_rq_v1.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+	"time"
+)
+
+type HTTPServerRequestMetricsV1 interface {
+	IncNbRequest(method string, statusCode int, supplierOldId int)
+	ObserveRequestDuration(method string, duration time.Duration)
+}
+
+type httpServerRequestMetricsV1 struct {
+	nbRequests    *prometheus.CounterVec
+	requestTimeMs *prometheus.HistogramVec
+}
+
+func (m *httpServerRequestMetricsV1) IncNbRequest(method string, statusCode int, supplierOldId int) {
+	m.nbRequests.WithLabelValues(method, strconv.Itoa(statusCode), strconv.Itoa(supplierOldId)).Inc()
+}
+
+func (m *httpServerRequestMetricsV1) ObserveRequestDuration(method string, duration time.Duration) {
+	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
+}
+
+func NewHTTPServerRequestMetricsV1() HTTPServerRequestMetricsV1 {
+	return NewHttpServerRequestMetricsWithBucketsV1(DefaultDurationMsBuckets)
+}
+
+func NewHttpServerRequestMetricsWithBucketsV1(requestTimeMsBuckets []float64) HTTPServerRequestMetricsV1 {
+	m := &httpServerRequestMetricsV1{
+		nbRequests:    newCounterVec(metricsNamespace, metricsSubsystemHttpServer, "nb_req", nil, []string{metricsLabelMethod, metricsLabelStatusCode, metricsLabelSupplierOldId}),
+		requestTimeMs: newHistogramVec(metricsNamespace, metricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metricsLabelMethod}),
+	}
+	return m
+}

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -2,7 +2,7 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
-func newCounter(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Counter {
+func NewCounter(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Counter {
 
 	if len(labelsOpt) == 0 { // no empty maps
 		labelsOpt = nil
@@ -19,7 +19,7 @@ func newCounter(ns, subsystem, name string, labelsOpt map[string]string) prometh
 	return m
 }
 
-func newCounterVec(ns, subsystem, name string, labelsOpt map[string]string, variableLabels []string) *prometheus.CounterVec {
+func NewCounterVec(ns, subsystem, name string, labelsOpt map[string]string, variableLabels []string) *prometheus.CounterVec {
 
 	if len(labelsOpt) == 0 { // no empty maps
 		labelsOpt = nil
@@ -37,7 +37,7 @@ func newCounterVec(ns, subsystem, name string, labelsOpt map[string]string, vari
 	return m
 }
 
-func newGauge(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Gauge {
+func NewGauge(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Gauge {
 
 	if len(labelsOpt) == 0 { // no empty maps
 		labelsOpt = nil
@@ -54,7 +54,7 @@ func newGauge(ns, subsystem, name string, labelsOpt map[string]string) prometheu
 	return m
 }
 
-func newSummary(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Summary {
+func NewSummary(ns, subsystem, name string, labelsOpt map[string]string) prometheus.Summary {
 
 	if len(labelsOpt) == 0 { // no empty maps
 		labelsOpt = nil
@@ -71,7 +71,7 @@ func newSummary(ns, subsystem, name string, labelsOpt map[string]string) prometh
 	return m
 }
 
-func newHistogram(ns, subsystem, name string, labelsOpt map[string]string, buckets []float64) prometheus.Histogram {
+func NewHistogram(ns, subsystem, name string, labelsOpt map[string]string, buckets []float64) prometheus.Histogram {
 
 	if len(labelsOpt) == 0 { // no empty maps
 		labelsOpt = nil
@@ -89,7 +89,7 @@ func newHistogram(ns, subsystem, name string, labelsOpt map[string]string, bucke
 	return m
 }
 
-func newHistogramVec(ns, subsystem, name string, labelsOpt map[string]string, buckets []float64, variableLabels []string) *prometheus.HistogramVec {
+func NewHistogramVec(ns, subsystem, name string, labelsOpt map[string]string, buckets []float64, variableLabels []string) *prometheus.HistogramVec {
 	if len(labelsOpt) == 0 {
 		labelsOpt = nil
 	}

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -88,3 +88,20 @@ func newHistogram(ns, subsystem, name string, labelsOpt map[string]string, bucke
 	prometheus.MustRegister(m)
 	return m
 }
+
+func newHistogramVec(ns, subsystem, name string, labelsOpt map[string]string, buckets []float64, variableLabels []string) *prometheus.HistogramVec {
+	if len(labelsOpt) == 0 {
+		labelsOpt = nil
+	}
+
+	m := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   ns,
+			Subsystem:   subsystem,
+			Name:        name,
+			ConstLabels: labelsOpt,
+			Buckets:     buckets,
+		}, variableLabels)
+	prometheus.MustRegister(m)
+	return m
+}

--- a/metrics/tac.go
+++ b/metrics/tac.go
@@ -1,11 +1,11 @@
 package metrics
 
 const (
-	metricsNamespace          = "sapi"
-	metricsLabelClient        = "client"
-	metricsLabelMethod        = "method"
-	metricsLabelStatusCode    = "status"
-	metricsLabelSupplierOldId = "supplierOldId"
-	metricsLabelDatabase      = "dbname"
-	metricsLabelDatabaseQuery = "query"
+	MetricsNamespace          = "sapi"
+	MetricsLabelClient        = "client"
+	MetricsLabelMethod        = "method"
+	MetricsLabelStatusCode    = "status"
+	MetricsLabelSupplierOldId = "supplierOldId"
+	MetricsLabelDatabase      = "dbname"
+	MetricsLabelDatabaseQuery = "query"
 )

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -8,30 +8,30 @@ import (
 	"github.com/happywbfriends/metrics/metrics"
 )
 
-type HTTPServerRequestMetricsV1 interface {
+func NewHTTPServerRequestMetrics() HTTPServerRequestMetrics {
+	return NewHttpServerRequestMetricsWithBuckets(metrics.DefaultDurationMsBuckets)
+}
+
+type HTTPServerRequestMetrics interface {
 	IncNbRequest(method string, statusCode int, supplierOldId int)
 	ObserveRequestDuration(method string, duration time.Duration)
 }
 
-type httpServerRequestMetricsV1 struct {
+type httpServerRequestMetrics struct {
 	nbRequests    *prometheus.CounterVec
 	requestTimeMs *prometheus.HistogramVec
 }
 
-func (m *httpServerRequestMetricsV1) IncNbRequest(method string, statusCode int, supplierOldId int) {
+func (m *httpServerRequestMetrics) IncNbRequest(method string, statusCode int, supplierOldId int) {
 	m.nbRequests.WithLabelValues(method, strconv.Itoa(statusCode), strconv.Itoa(supplierOldId)).Inc()
 }
 
-func (m *httpServerRequestMetricsV1) ObserveRequestDuration(method string, duration time.Duration) {
+func (m *httpServerRequestMetrics) ObserveRequestDuration(method string, duration time.Duration) {
 	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
 }
 
-func NewHTTPServerRequestMetricsV1() HTTPServerRequestMetricsV1 {
-	return NewHttpServerRequestMetricsWithBucketsV1(metrics.DefaultDurationMsBuckets)
-}
-
-func NewHttpServerRequestMetricsWithBucketsV1(requestTimeMsBuckets []float64) HTTPServerRequestMetricsV1 {
-	m := &httpServerRequestMetricsV1{
+func NewHttpServerRequestMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerRequestMetrics {
+	m := &httpServerRequestMetrics{
 		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
 		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
 	}

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -8,30 +8,30 @@ import (
 	"github.com/happywbfriends/metrics/metrics"
 )
 
-func NewHTTPServerRequestMetrics() HTTPServerRequestMetrics {
-	return NewHttpServerRequestMetricsWithBuckets(metrics.DefaultDurationMsBuckets)
+func NewHTTPServerMetrics() HTTPServerMetrics {
+	return NewHttpServerMetricsWithBuckets(metrics.DefaultDurationMsBuckets)
 }
 
-type HTTPServerRequestMetrics interface {
+type HTTPServerMetrics interface {
 	IncNbRequest(method string, statusCode int, supplierOldId int)
 	ObserveRequestDuration(method string, duration time.Duration)
 }
 
-type httpServerRequestMetrics struct {
+type httpServerMetrics struct {
 	nbRequests    *prometheus.CounterVec
 	requestTimeMs *prometheus.HistogramVec
 }
 
-func (m *httpServerRequestMetrics) IncNbRequest(method string, statusCode int, supplierOldId int) {
+func (m *httpServerMetrics) IncNbRequest(method string, statusCode int, supplierOldId int) {
 	m.nbRequests.WithLabelValues(method, strconv.Itoa(statusCode), strconv.Itoa(supplierOldId)).Inc()
 }
 
-func (m *httpServerRequestMetrics) ObserveRequestDuration(method string, duration time.Duration) {
+func (m *httpServerMetrics) ObserveRequestDuration(method string, duration time.Duration) {
 	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
 }
 
-func NewHttpServerRequestMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerRequestMetrics {
-	m := &httpServerRequestMetrics{
+func NewHttpServerMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerMetrics {
+	m := &httpServerMetrics{
 		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
 		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
 	}

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -14,7 +14,7 @@ func NewHTTPServerMetrics() HTTPServerMetrics {
 
 type HTTPServerMetrics interface {
 	IncNbRequest(method string, statusCode int, supplierOldId int)
-	ObserveRequestDuration(method string, duration time.Duration)
+	ObserveOkRequestDuration(method string, duration time.Duration)
 }
 
 type httpServerMetrics struct {
@@ -26,7 +26,7 @@ func (m *httpServerMetrics) IncNbRequest(method string, statusCode int, supplier
 	m.nbRequests.WithLabelValues(method, strconv.Itoa(statusCode), strconv.Itoa(supplierOldId)).Inc()
 }
 
-func (m *httpServerMetrics) ObserveRequestDuration(method string, duration time.Duration) {
+func (m *httpServerMetrics) ObserveOkRequestDuration(method string, duration time.Duration) {
 	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
 }
 

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -15,7 +15,7 @@ func NewHTTPServerMetrics() HTTPServerMetrics {
 func NewHttpServerMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerMetrics {
 	m := &httpServerMetrics{
 		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
-		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
+		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelSupplierOldId}),
 		nbConnections: metrics.NewGauge(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "current_conns", nil),
 	}
 	return m
@@ -23,7 +23,7 @@ func NewHttpServerMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerM
 
 type HTTPServerMetrics interface {
 	IncNbRequest(method string, statusCode int, supplierOldId int)
-	ObserveOkRequestDuration(method string, duration time.Duration)
+	ObserveOkRequestDuration(method string, supplierOldId int, duration time.Duration)
 	IncNbConnections()
 	DecNbConnections()
 }
@@ -38,8 +38,8 @@ func (m *httpServerMetrics) IncNbRequest(method string, statusCode int, supplier
 	m.nbRequests.WithLabelValues(method, strconv.Itoa(statusCode), strconv.Itoa(supplierOldId)).Inc()
 }
 
-func (m *httpServerMetrics) ObserveOkRequestDuration(method string, duration time.Duration) {
-	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
+func (m *httpServerMetrics) ObserveOkRequestDuration(method string, supplierOldId int, duration time.Duration) {
+	m.requestTimeMs.WithLabelValues(method, strconv.Itoa(supplierOldId)).Observe(float64(duration.Milliseconds()))
 }
 
 func (m *httpServerMetrics) IncNbConnections() {

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -12,14 +12,26 @@ func NewHTTPServerMetrics() HTTPServerMetrics {
 	return NewHttpServerMetricsWithBuckets(metrics.DefaultDurationMsBuckets)
 }
 
+func NewHttpServerMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerMetrics {
+	m := &httpServerMetrics{
+		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
+		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
+		nbConnections: metrics.NewGauge(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "current_conns", nil),
+	}
+	return m
+}
+
 type HTTPServerMetrics interface {
 	IncNbRequest(method string, statusCode int, supplierOldId int)
 	ObserveOkRequestDuration(method string, duration time.Duration)
+	IncNbConnections()
+	DecNbConnections()
 }
 
 type httpServerMetrics struct {
 	nbRequests    *prometheus.CounterVec
 	requestTimeMs *prometheus.HistogramVec
+	nbConnections prometheus.Gauge
 }
 
 func (m *httpServerMetrics) IncNbRequest(method string, statusCode int, supplierOldId int) {
@@ -30,10 +42,10 @@ func (m *httpServerMetrics) ObserveOkRequestDuration(method string, duration tim
 	m.requestTimeMs.WithLabelValues(method).Observe(float64(duration.Milliseconds()))
 }
 
-func NewHttpServerMetricsWithBuckets(requestTimeMsBuckets []float64) HTTPServerMetrics {
-	m := &httpServerMetrics{
-		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
-		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
-	}
-	return m
+func (m *httpServerMetrics) IncNbConnections() {
+	m.nbConnections.Inc()
+}
+
+func (m *httpServerMetrics) DecNbConnections() {
+	m.nbConnections.Dec()
 }

--- a/v1/http_srv.go
+++ b/v1/http_srv.go
@@ -1,9 +1,11 @@
-package metrics
+package v1
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"strconv"
 	"time"
+
+	"github.com/happywbfriends/metrics/metrics"
 )
 
 type HTTPServerRequestMetricsV1 interface {
@@ -25,13 +27,13 @@ func (m *httpServerRequestMetricsV1) ObserveRequestDuration(method string, durat
 }
 
 func NewHTTPServerRequestMetricsV1() HTTPServerRequestMetricsV1 {
-	return NewHttpServerRequestMetricsWithBucketsV1(DefaultDurationMsBuckets)
+	return NewHttpServerRequestMetricsWithBucketsV1(metrics.DefaultDurationMsBuckets)
 }
 
 func NewHttpServerRequestMetricsWithBucketsV1(requestTimeMsBuckets []float64) HTTPServerRequestMetricsV1 {
 	m := &httpServerRequestMetricsV1{
-		nbRequests:    newCounterVec(metricsNamespace, metricsSubsystemHttpServer, "nb_req", nil, []string{metricsLabelMethod, metricsLabelStatusCode, metricsLabelSupplierOldId}),
-		requestTimeMs: newHistogramVec(metricsNamespace, metricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metricsLabelMethod}),
+		nbRequests:    metrics.NewCounterVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "nb_req", nil, []string{metrics.MetricsLabelMethod, metrics.MetricsLabelStatusCode, metrics.MetricsLabelSupplierOldId}),
+		requestTimeMs: metrics.NewHistogramVec(metrics.MetricsNamespace, metrics.MetricsSubsystemHttpServer, "req_duration_ms", nil, requestTimeMsBuckets, []string{metrics.MetricsLabelMethod}),
 	}
 	return m
 }

--- a/v1_example.go
+++ b/v1_example.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	v1 "github.com/happywbfriends/metrics/v1"
+	metricsv1 "github.com/happywbfriends/metrics/v1"
 	"net/http"
 	"time"
 )
@@ -11,7 +11,7 @@ func v1HTTPServerExample() {
 
 	timeBegin := time.Now()
 	status := http.StatusNotFound
-	httpServerMetrics := v1.NewHTTPServerMetrics()
+	httpServerMetrics := metricsv1.NewHTTPServerMetrics()
 	httpServerMetrics.IncNbRequest("POST/foo", status, supplierOldId)
 	if status == http.StatusOK {
 		httpServerMetrics.ObserveOkRequestDuration("POST/foo", time.Since(timeBegin))

--- a/v1_example.go
+++ b/v1_example.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	v1 "github.com/happywbfriends/metrics/v1"
+	"net/http"
+	"time"
+)
+
+func v1HTTPServerExample() {
+	supplierOldId := 999
+
+	timeBegin := time.Now()
+	status := http.StatusNotFound
+	httpServerMetrics := v1.NewHTTPServerMetrics()
+	httpServerMetrics.IncNbRequest("POST/foo", status, supplierOldId)
+	if status == http.StatusOK {
+		httpServerMetrics.ObserveOkRequestDuration("POST/foo", time.Since(timeBegin))
+	}
+}

--- a/v1_example.go
+++ b/v1_example.go
@@ -9,11 +9,24 @@ import (
 func v1HTTPServerExample() {
 	supplierOldId := 999
 
-	timeBegin := time.Now()
-	status := http.StatusNotFound
 	httpServerMetrics := metricsv1.NewHTTPServerMetrics()
-	httpServerMetrics.IncNbRequest("POST/foo", status, supplierOldId)
-	if status == http.StatusOK {
-		httpServerMetrics.ObserveOkRequestDuration("POST/foo", time.Since(timeBegin))
-	}
+
+	// Обработчик /bar
+	http.HandleFunc("GET/bar", func(w http.ResponseWriter, r *http.Request) {
+		method := "GET/bar"
+		httpServerMetrics.IncNbConnections()
+		defer httpServerMetrics.DecNbConnections()
+
+		timeBegin := time.Now()
+		status := http.StatusOK
+		defer func() {
+			if status == http.StatusOK {
+				httpServerMetrics.ObserveOkRequestDuration(method, time.Since(timeBegin))
+			}
+
+			httpServerMetrics.IncNbRequest(method, status, supplierOldId)
+		}()
+
+		w.WriteHeader(status)
+	})
 }

--- a/v1_example.go
+++ b/v1_example.go
@@ -21,7 +21,7 @@ func v1HTTPServerExample() {
 		status := http.StatusOK
 		defer func() {
 			if status == http.StatusOK {
-				httpServerMetrics.ObserveOkRequestDuration(method, time.Since(timeBegin))
+				httpServerMetrics.ObserveOkRequestDuration(method, supplierOldId, time.Since(timeBegin))
 			}
 
 			httpServerMetrics.IncNbRequest(method, status, supplierOldId)


### PR DESCRIPTION
* примеры в main.go приведены в соответствие пакету metrics
* добавлена функция NewHistogramVec
* функции и константы пакета metrics сделаны public для реиспользования в других пакетах
* добавлен пакет v1, т.е. старый интерфейс не ломается, можно спокойно пареллально использовать обе версии
* в пакете v1 сделаны метрики сервера - nb_req, req_duration_ms и current_conns в одном флаконе